### PR TITLE
Remove unused imports

### DIFF
--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -1,7 +1,3 @@
-import numpy as np
-import faiss
-import json
-from pathlib import Path
 from typing import List, Dict, Any
 from bedrock_wrapper import embed_texts, generate_answer
 from retriever import RAGRetriever


### PR DESCRIPTION
## Summary
- clean up imports in `rag_pipeline.py`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6850649584a083228fd963ffe45cd8be