### PR TITLE
Add docs folder

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Documentation
+
+This directory contains documentation for the RAG Research Agent.
+
+* `usage.md` - Details on running the pipeline and using the command-line interface.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,7 @@
+# Usage Guide
+
+This guide explains how to set up and run the RAG Research Agent for analyzing documents with AWS Bedrock.
+
+1. Configure AWS credentials.
+2. Run `embed_and_store_chunks.py` to preprocess PDFs.
+3. Use `rag_pipeline.py` to query the document store.


### PR DESCRIPTION
## Summary
- add `docs/` folder with initial documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6850649bae808322829084a1969854f1