### PR TITLE
Add environment template and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # AWS Credentials
 AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
-AWS_REGION=your_aws_region_here  # e.g., us-east-1
+AWS_DEFAULT_REGION=your_aws_region_here  # e.g., us-east-1
 
 # S3 Configuration
 S3_BUCKET_NAME=your_bucket_name_here

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-3. Configure AWS credentials:
+3. Copy `.env.example` to `.env` and fill in your AWS credentials and S3 bucket details:
+```bash
+cp .env.example .env
+```
+
+4. Configure AWS credentials:
 - Ensure you have AWS credentials configured with appropriate permissions for Bedrock and S3
 - Set up your AWS credentials in `~/.aws/credentials` or using environment variables
 


### PR DESCRIPTION
## Summary
- provide example env vars in `.env.example`
- update setup instructions in README to mention copying `.env.example`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_685064ab615c832294b8f7fec956f5cc