### PR TITLE
Introduce modular agentic pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ After it completes you should see these files inside the `cache/` directory:
 - `tests/`: Directory containing all test files
 - `docs/`: Documentation
 - `notebooks/`: Jupyter notebooks for experimentation
+- `vector_retriever.py`: LangChain-based vector store retriever
+- `agent_module.py`: Creates the ReAct agent wired with tools
+- `tool_modules/`: Collection of LangChain tools
+- `observability.py`: Logging and CloudWatch metric helpers
+- `lambda_query.py`/`lambda_ingest.py`: AWS Lambda entrypoints
 
 ## Testing
 

--- a/agent_module.py
+++ b/agent_module.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from langchain.agents import initialize_agent, AgentType
+from langchain.llms import Bedrock
+
+from vector_retriever import VectorRetriever
+from tool_modules import tool_list
+
+
+def create_agent():
+    """Initialize a LangChain ReAct agent with tools and retriever."""
+    llm = Bedrock(model_id="amazon.titan-text-express-v1")
+    retriever = VectorRetriever()
+    retrieval_tool = retriever.as_langchain_tool(name="search_docs", description="Search cached documents")
+
+    tools = [retrieval_tool] + tool_list()
+
+    agent = initialize_agent(
+        tools=tools,
+        llm=llm,
+        agent=AgentType.REACT_DESCRIPTION,
+        verbose=True,
+    )
+    return agent

--- a/lambda_ingest.py
+++ b/lambda_ingest.py
@@ -1,0 +1,5 @@
+from embed_and_store_chunks import process_documents
+
+def lambda_handler(event, context):
+    process_documents()
+    return {"statusCode": 200}

--- a/lambda_query.py
+++ b/lambda_query.py
@@ -1,0 +1,10 @@
+from agent_module import create_agent
+
+agent = create_agent()
+
+def lambda_handler(event, context):
+    query = event.get("query", "")
+    if not query:
+        return {"statusCode": 400, "body": "Missing query"}
+    response = agent.run(query)
+    return {"statusCode": 200, "body": response}

--- a/main_agent.py
+++ b/main_agent.py
@@ -1,0 +1,14 @@
+from agent_module import create_agent
+
+agent = create_agent()
+
+
+def run_query(query: str) -> str:
+    return agent.run(query)
+
+
+if __name__ == "__main__":
+    import sys
+
+    q = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Hello"
+    print(run_query(q))

--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,17 @@
+import logging
+import boto3
+
+logger = logging.getLogger("rag_agent")
+logger.setLevel(logging.INFO)
+
+
+def record_metric(name: str, value: float) -> None:
+    """Publish a custom CloudWatch metric."""
+    try:
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="RAGAgent",
+            MetricData=[{"MetricName": name, "Value": value}],
+        )
+    except Exception as exc:
+        logger.error("Failed to record metric %s: %s", name, exc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy>=1.24.0
 python-dotenv>=1.0.0
 fastapi>=0.104.0
 uvicorn>=0.24.0 
+langchain>=0.1.0
+sympy>=1.12

--- a/tool_modules/__init__.py
+++ b/tool_modules/__init__.py
@@ -1,0 +1,5 @@
+from .math_tool import math_tool
+
+
+def tool_list():
+    return [math_tool]

--- a/tool_modules/math_tool.py
+++ b/tool_modules/math_tool.py
@@ -1,0 +1,15 @@
+from langchain.agents import Tool
+import sympy as sp
+
+
+def solve_math(expression: str) -> str:
+    try:
+        return str(sp.simplify(expression))
+    except Exception as exc:
+        return f"Error: {exc}"
+
+math_tool = Tool(
+    name="calculator",
+    func=solve_math,
+    description="Solve math expressions"
+)

--- a/vector_retriever.py
+++ b/vector_retriever.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+from langchain.embeddings import BedrockEmbeddings
+from langchain.vectorstores import FAISS
+
+
+class VectorRetriever:
+    """LangChain based vector retriever."""
+
+    def __init__(self, index_path: str = "cache/faiss_index.bin", chunks_path: str = "cache/chunks.json"):
+        self.index_path = Path(index_path)
+        self.chunks_path = Path(chunks_path)
+        if not self.index_path.exists() or not self.chunks_path.exists():
+            raise ValueError("Index and chunks not found. Run embed_and_store_chunks.py first")
+
+        self.embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0")
+        self.store = FAISS.load_local(str(self.index_path), self.embeddings)
+        with self.chunks_path.open() as f:
+            self.chunks: List[Dict[str, Any]] = json.load(f)
+
+    def retrieve(self, query: str, k: int = 3) -> List[Dict[str, Any]]:
+        """Return top-k chunks for query."""
+        docs = self.store.similarity_search(query, k=k)
+        results: List[Dict[str, Any]] = []
+        for d in docs:
+            idx = d.metadata.get("idx")
+            meta = self.chunks[idx] if idx is not None and idx < len(self.chunks) else {}
+            results.append({"text": d.page_content, **meta})
+        return results
+
+    def as_langchain_tool(self, name: str = "search_docs", description: str = "Search cached documents"):
+        from langchain.agents import Tool
+
+        def _run(q: str) -> str:
+            chunks = self.retrieve(q, k=3)
+            return "\n".join(chunk["text"] for chunk in chunks)
+
+        return Tool(name=name, func=_run, description=description)


### PR DESCRIPTION
## Summary
- add LangChain-based `VectorRetriever`
- implement `create_agent` factory
- modularize tool collection with a math tool example
- provide observability helpers and Lambda handlers
- update requirements and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6852c4a251cc83229fcc1f7090274d33